### PR TITLE
Implemented ignoreRelations setting.

### DIFF
--- a/EActiveRecordRelationBehavior.php
+++ b/EActiveRecordRelationBehavior.php
@@ -19,7 +19,6 @@
  *
  * Limitations:
  * - currently does not support composite primary keys
- * - currently handles all existing relations, will add support for limitation shortly
  * - relations defined with 'through' are not supported yet (http://www.yiiframework.com/doc/guide/1.1/en/database.arr#relational-query-with-through)
  *
  * @property CActiveRecord $owner The owner AR that this behavior is attached to.
@@ -38,6 +37,11 @@ class EActiveRecordRelationBehavior extends CActiveRecordBehavior
 	 */
 	public $useTransaction=true;
 	/**
+	 * @var array allows to configure which relations should be ignored by default
+	 * This option will only be considered when withRelations() or withoutRelations() is not used
+	 */
+	public $ignoreRelations=array();
+	/**
 	 * @var CDbTransaction
 	 */
 	private $_transaction;
@@ -45,7 +49,6 @@ class EActiveRecordRelationBehavior extends CActiveRecordBehavior
 	 * Holds active relations to be saved. null means all relations.
 	 */
 	protected $_enabledRelations;
-
 
 	/**
 	 * @return CDbTransaction The transaction that is used while updating the database.
@@ -470,8 +473,14 @@ class EActiveRecordRelationBehavior extends CActiveRecordBehavior
 	protected function getRelations()
 	{
 		if (is_null($this->_enabledRelations))
+		{
+			if (count($this->ignoreRelations) > 0)
+			{
+				$diff = array_combine($this->ignoreRelations, $this->ignoreRelations);
+				return array_diff_key($this->owner->relations(), $diff);
+			}
 			return $this->owner->relations();
-
+		}
 		return array_intersect_key($this->owner->relations(), array_flip($this->_enabledRelations));
 	}
 }

--- a/EActiveRecordRelationBehaviorTest.php
+++ b/EActiveRecordRelationBehaviorTest.php
@@ -26,7 +26,7 @@ namespace yiiext\behaviors\activeRecordRelation\tests;
 define('TEST_NAMESPACE', 'yiiext\behaviors\activeRecordRelation\tests');
 
 if (!defined('YII_PATH')) {
-	$yii = dirname(__FILE__).'/vendor/yiisoft/yii/framework/yiit.php';
+	$yii = dirname(__FILE__).'/yii/framework/yiit.php';
 	require_once($yii);
 }
 
@@ -736,6 +736,145 @@ class EActiveRecordRelationBehaviorTest extends \CTestCase
 		$this->assertInstanceOf('CDbTransaction', $transaction);
 		$this->assertSame($transaction, $behavior->getTransaction());
 	}
+	
+	/**
+	 * tests if withRelations() words correctly
+	 *
+	 * @dataProvider fkConfigurationProvider
+	 */
+	public function testSaveWithRelations($config, $transactional)
+	{
+		$this->setConfig($config);
+		$this->startTransaction($transactional);
+		
+		// create test data
+		// -- user
+		$jane = $this->getJane(10, true);
+		// -- profile
+		$profile = new Profile();
+		$profile->disableOwnerRule = true;
+		$profile->photo = "Jane's Photo";
+		$profile->website = "jane.doe.com";
+		$profile->save();
+		// -- posts
+		$posts = $this->getPosts(10);
+		
+		// set profile and posts for jane
+		$jane->profile = $profile;
+		$jane->posts = $posts;
+		
+		// save posts only
+		$jane->withRelations('posts')->save();
+		$jane->refresh();
+		
+		$this->assertNull($jane->profile);
+		$this->assertEquals(9, count($jane->posts));
+		
+		// set profile and posts for jane again
+		$jane->profile = $profile;
+		$jane->posts = $posts;
+		
+		// save posts and profile
+		$jane->withRelations('posts', 'profile')->save();
+		$jane->refresh();
+		
+		$this->assertEquals(9, count($jane->posts));
+		$this->assertEquals("jane.doe.com", $jane->profile->website);
+		
+		$this->endTransaction($transactional);
+	}
+	
+	/**
+	 * tests if withoutRelations() words correctly
+	 *
+	 * @dataProvider fkConfigurationProvider
+	 */
+	public function testSaveWithoutRelations($config, $transactional)
+	{
+		$this->setConfig($config);
+		$this->startTransaction($transactional);
+		
+		// create test data
+		// -- user
+		$jane = $this->getJane(10, true);
+		// -- profile#1
+		$profile1 = new Profile();
+		$profile1->disableOwnerRule = true;
+		$profile1->photo = "Jane's Photo";
+		$profile1->website = "jane.doe.com";
+		$profile1->save();
+		// -- profile#2
+		$profile2 = new Profile();
+		$profile2->disableOwnerRule = true;
+		$profile2->photo = "Jane's Photo";
+		$profile2->website = "jane.doe.io";
+		$profile2->save();
+		// -- posts
+		$posts = $this->getPosts(10);
+		
+		// set profile and posts for jane
+		$jane->profile = $profile1;
+		$jane->posts = $posts;
+		
+		// save profile only
+		$jane->withoutRelations('posts')->save();
+		$jane->refresh();
+		
+		$this->assertEquals(0, count($jane->posts));
+		$this->assertEquals("jane.doe.com", $jane->profile->website);
+		
+		// set profile and posts for jane again
+		$jane->profile = $profile2;
+		$jane->posts = $posts;
+		
+		// save posts only
+		$jane->withoutRelations('profile')->save();
+		$jane->refresh();
+		
+		$this->assertEquals(9, count($jane->posts));
+		$this->assertEquals("jane.doe.com", $jane->profile->website);
+		
+		$this->endTransaction($transactional);
+	}
+	
+	/**
+	 * tests if setting ignoreRelations works as expected
+	 *
+	 * @dataProvider fkConfigurationProvider
+	 */
+	public function testIgnoreRelations($config, $transactional)
+	{
+		$this->setConfig($config);
+		$this->startTransaction($transactional);
+		
+		// set ignore relations for user
+		User::$ignoreRelations = array('profile');
+		
+		// create test data
+		// -- user
+		$jane = $this->getJane(10, true);
+		// -- profile
+		$profile = new Profile();
+		$profile->disableOwnerRule = true;
+		$profile->photo = "Jane's Photo";
+		$profile->website = "jane.doe.com";
+		$profile->save();
+		// -- posts
+		$posts = $this->getPosts(10);
+		
+		// set profile and posts for jane
+		$jane->profile = $profile;
+		$jane->posts = $posts;
+		
+		// save profile only
+		$jane->save();
+		$jane->refresh();
+		
+		$this->assertEquals(9, count($jane->posts));
+		$this->assertNull($jane->profile);
+		
+		$this->endTransaction($transactional);
+	}
 
 	/**
 	 * @param \CActiveRecord $ar
@@ -902,6 +1041,7 @@ class Profile extends \CActiveRecord
 {
 	public static $configurationType='normal';
 	public $disableOwnerRule=false;
+	public $eActiveRecordRelationBehavior_ignoreRelations=array();
 	/**
 	 * Returns the static model of the specified AR class.
 	 * @param string $className active record class name.
@@ -975,6 +1115,7 @@ class Profile extends \CActiveRecord
 class User extends \CActiveRecord
 {
 	public static $configurationType='normal';
+	public static $ignoreRelations=array();
 	/**
 	 * Returns the static model of the specified AR class.
 	 * @param string $className active record class name.
@@ -998,7 +1139,12 @@ class User extends \CActiveRecord
 	 */
 	public function behaviors()
 	{
-		return array('activeRecordRelationBehavior'=>'EActiveRecordRelationBehavior');
+		return array(
+			'activeRecordRelationBehavior'=>array(
+				'class'=>'EActiveRecordRelationBehavior',
+				'ignoreRelations'=>self::$ignoreRelations,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Implemented ignoreRelations setting that allows to define relations that should be ignored by default -- see issue https://github.com/yiiext/activerecord-relation-behavior/issues/8

**Caution: I've seen that I committed something by mistake -- please remove the change EActiveRecordRelationBehaviorTest on line 29** (I changed the default path to Yii because I didn't use Composer)
