### PR TITLE
Add check for mapped related keys

### DIFF
--- a/EActiveRecordRelationBehavior.php
+++ b/EActiveRecordRelationBehavior.php
@@ -297,7 +297,8 @@ class EActiveRecordRelationBehavior extends CActiveRecordBehavior
 		}
 
 		// @todo add support for composite primary keys
-		if (!is_array($pk)) {
+		// @todo add support for relation keys mapping
+		if (!is_array($pk) && !is_array($relation[2])) {
 			$this->owner->setAttribute($relation[2], $pk);
 		}
 	}


### PR DESCRIPTION
In the case of a relation key mapping to a non-primary key in the related model, an exception will happen.
For example:
'related' => array(self::BELONGS_TO, 'RelatedModel', array('field' => 'non-pk')),